### PR TITLE
Improved conwall and command line alias

### DIFF
--- a/Aardwolf_Consider_Miniwin.xml
+++ b/Aardwolf_Consider_Miniwin.xml
@@ -667,7 +667,17 @@
 	</alias>
 	<alias
 		script="Command_line"
-		match="^(\d+)\s?(\w*)$"
+		match="^(\d+)\s+(\w*)$"
+		enabled="y"
+		regexp="y"
+		send_to="12"
+		keep_evaluating="y"
+		sequence="1"
+		>
+	</alias>
+	<alias
+		script="Command_line"
+		match="^(\d+)$"
 		enabled="y"
 		regexp="y"
 		send_to="12"


### PR DESCRIPTION
* Fixed command line alias, it was matching strings such as 1foo, rather than only support 1 or 1 foo
* conwall will now correctly target the number of mobs if toggle skip settings are used.  Previously if you had MaxRoomCount set to 3, SkipEvil set, and were in a room with 3 evil mobs and then 5 good mobs, it wouldn't attack anything.  Now it will correctly skip the first 3 evil mobs and attack 3 good mobs.